### PR TITLE
Add basic React Native mood tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CapyCare
+
+A simple React Native app for tracking daily emotions with guidance from a capybara friend.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run with React Native CLI or Expo.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "capycare",
+  "displayName": "CapyCare"
+}

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "capycare",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-native": "^0.79.3"
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Slider, Button, ScrollView } from 'react-native';
+import { getColorForValue, getAverageColor } from '../utils/moodColor';
+
+export default function App() {
+  const [stress, setStress] = useState(5);
+  const [happiness, setHappiness] = useState(5);
+  const [energy, setEnergy] = useState(5);
+  const [note, setNote] = useState('');
+
+  const handleSubmit = () => {
+    // Placeholder for storing mood locally
+    console.log('Mood submitted', { stress, happiness, energy, note });
+  };
+
+  const colors = [
+    getColorForValue(stress),
+    getColorForValue(happiness),
+    getColorForValue(energy),
+  ];
+  const averageColor = getAverageColor([stress, happiness, energy]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.header}>CapyCare</Text>
+      <MoodSlider label="Stress" value={stress} setValue={setStress} color={colors[0]} />
+      <MoodSlider label="Happiness" value={happiness} setValue={setHappiness} color={colors[1]} />
+      <MoodSlider label="Energy" value={energy} setValue={setEnergy} color={colors[2]} />
+      <View style={[styles.moodTile, { backgroundColor: averageColor }]} />
+      <Button title="Submit" onPress={handleSubmit} />
+    </ScrollView>
+  );
+}
+
+function MoodSlider({ label, value, setValue, color }) {
+  return (
+    <View style={styles.sliderContainer}>
+      <Text style={styles.label}>{label}: {value}</Text>
+      <Slider
+        minimumValue={1}
+        maximumValue={10}
+        step={1}
+        value={value}
+        onValueChange={setValue}
+        minimumTrackTintColor={color}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+    backgroundColor: '#F5F5F5',
+  },
+  header: {
+    fontSize: 24,
+    marginBottom: 20,
+  },
+  sliderContainer: {
+    width: '100%',
+    marginVertical: 10,
+  },
+  label: {
+    fontSize: 16,
+    marginBottom: 5,
+  },
+  moodTile: {
+    width: 100,
+    height: 100,
+    borderRadius: 10,
+    marginVertical: 20,
+  },
+});

--- a/utils/moodColor.js
+++ b/utils/moodColor.js
@@ -1,0 +1,28 @@
+export function getColorForValue(value) {
+  if (value <= 3) {
+    return shadeColor('#0000FF', value, 1); // Blue shades
+  } else if (value <= 6) {
+    return shadeColor('#FFFF00', value - 3, 2); // Yellow shades
+  } else {
+    return shadeColor('#00FF00', value - 6, 3); // Green shades
+  }
+}
+
+function shadeColor(base, offset, range) {
+  // Darker at lower values, lighter at higher values within range
+  const factor = offset / range; // 0 to 1
+  // Simple lighten formula
+  const lighten = Math.round(255 * (1 - factor)).toString(16).padStart(2, '0');
+  if (base === '#0000FF') {
+    return `#0000${lighten}`;
+  } else if (base === '#FFFF00') {
+    return `#${lighten}${lighten}00`;
+  } else {
+    return `#00${lighten}00`;
+  }
+}
+
+export function getAverageColor(values) {
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+  return getColorForValue(Math.round(avg));
+}


### PR DESCRIPTION
## Summary
- initialize React Native project with simple mood tracking sliders
- implement color mapping utilities for moods
- show a daily mood tile that blends slider moods

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68477ee9ac5883298a135014b6758e75